### PR TITLE
Fix mismatched iOS PermissionLevel enum

### DIFF
--- a/packages/location_permissions/ios/Classes/Enums.h
+++ b/packages/location_permissions/ios/Classes/Enums.h
@@ -7,8 +7,8 @@
 
 typedef NS_ENUM(int, PermissionLevel) {
   PermissionLevelLocation = 0,
-  PermissionLevelLocationAlways,
   PermissionLevelLocationWhenInUse,
+  PermissionLevelLocationAlways,
 };
 
 typedef NS_ENUM(int, PermissionStatus) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes the iOS PermissionLevel enum mapping.

### :arrow_heading_down: What is the current behavior?
The library fails to work if you request only PermissionLevelLocationWhenInUse or PermissionLevelLocationAlways and supply a string for solely one of them in Info.plist - additionally, the wrong permission level is being requested.

### :new: What is the new behavior (if this is a feature change)?
The permission level works as expected.

### :boom: Does this PR introduce a breaking change?
Unlikely

### :memo: Links to relevant issues/docs
https://github.com/BaseflowIT/flutter-permission-plugins/issues/6

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop