### PR TITLE
Fixed broadcast receiver leaking when FlutterNativeView is destroyed.

### DIFF
--- a/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
+++ b/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
@@ -26,6 +26,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /** LocationPermissionsPlugin */
-public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandler {
+public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandler, PluginRegistry.ViewDestroyListener {
   private static final String LOG_TAG = "location_permissions";
   private static final int PERMISSION_CODE = 25;
 
@@ -92,6 +93,7 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
         new LocationPermissionsPlugin(registrar);
     channel.setMethodCallHandler(locationPermissionsPlugin);
     eventChannel.setStreamHandler(locationPermissionsPlugin);
+    registrar.addViewDestroyListener(locationPermissionsPlugin);
 
     registrar.addRequestPermissionsResultListener(
         new PluginRegistry.RequestPermissionsResultListener() {
@@ -181,6 +183,15 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
       mRegistrar.context().unregisterReceiver(mReceiver);
       mEventSink = null;
     }
+  }
+
+  @Override
+  public boolean onViewDestroy(FlutterNativeView flutterNativeView) {
+    if (mEventSink != null) {
+      mRegistrar.context().unregisterReceiver(mReceiver);
+      mEventSink = null;
+    }
+    return false;
   }
 
   @PermissionStatus


### PR DESCRIPTION
### :sparkles: Bug Fix


### :arrow_heading_down: Currently, when the FlutterNativeView is destroyed and there is a registration to the LocationManagerMODE_CHANGED_ACTION broadcast receiver, then the broadcast receiver is leaked (a warning is printed as well to the logs by Android system)


### :new: What is the new behavior (if this is a feature change)?
A PluginRegistry.ViewDestroyListener is implemented and registered. If the FlutterNativeView is destroyed, then the broadcast receiver is unregistered.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
This is Android only change. Try situations where the FlutterNativeView is destroyed and a listener attached to the serviceStatus stream. This is my first Pull request ever, so I would advise extra caution.

### :memo: Links to relevant issues/docs
Did not create an issue, but should have done. 

### :thinking: Checklist before submitting


- [x ] All projects build
- [ x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [ x] Relevant documentation was updated
- [ -] Rebased onto current develop