### PR TITLE
Adds support for Android 10’s background location permission

### DIFF
--- a/packages/location_permissions/README.md
+++ b/packages/location_permissions/README.md
@@ -22,7 +22,7 @@ To use this plugin, add `location_permissions` as a [dependency in your pubspec.
 
 ```yaml
 dependencies:
-  location_permissions: '^2.0.0'
+  location_permissions: '^2.0.3'
 ```
 
 > **NOTE:** The location_permissions plugin uses the AndroidX version of the Android Support Libraries. This means you need to make sure your Android project is also upgraded to support AndroidX. Detailed instructions can be found [here](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility). 
@@ -39,7 +39,7 @@ dependencies:
 >
 >```
 >android {
->  compileSdkVersion 28
+>  compileSdkVersion 29
 >
 >  ...
 >}

--- a/packages/location_permissions/android/build.gradle
+++ b/packages/location_permissions/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
+++ b/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
@@ -278,7 +278,8 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
 
   private static Boolean isLocationPermission(String permission) {
     return permission.equals(Manifest.permission.ACCESS_COARSE_LOCATION)
-        || permission.equals(Manifest.permission.ACCESS_FINE_LOCATION);
+            || permission.equals(Manifest.permission.ACCESS_FINE_LOCATION)
+            || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && permission.equals(Manifest.permission.ACCESS_BACKGROUND_LOCATION));
   }
 
   @PermissionStatus
@@ -302,6 +303,10 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
 
     if (hasPermissionInManifest(Manifest.permission.ACCESS_FINE_LOCATION, context)) {
       permissionNames.add(Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasPermissionInManifest(Manifest.permission.ACCESS_BACKGROUND_LOCATION, context)) {
+      permissionNames.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
     }
 
     return permissionNames;

--- a/packages/location_permissions/pubspec.yaml
+++ b/packages/location_permissions/pubspec.yaml
@@ -1,7 +1,7 @@
 name: location_permissions
 description: Location permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to check and request access to the location services on the
   device.
-version: 2.0.2
+version: 2.0.3
 authors:
   - Baseflow <hello@baseflow.com>
 homepage: https://github.com/BaseflowIT/flutter-permission-plugins/tree/develop/packages/location_permissions 


### PR DESCRIPTION
This is a relatively minor PR that adds support for the new background location permission in Android 10.

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop