### PR TITLE
Correct the Android compileSdk version documentation

### DIFF
--- a/packages/location_permissions/README.md
+++ b/packages/location_permissions/README.md
@@ -35,11 +35,11 @@ dependencies:
 >android.useAndroidX=true
 >android.enableJetifier=true
 >```
->2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
+>2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28 or higher:
 >
 >```
 >android {
->  compileSdkVersion 29
+>  compileSdkVersion 28
 >
 >  ...
 >}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Docs

### :arrow_heading_down: What is the current behavior?

Currently the README.md describes that the user should set the "compileSDK" value to 28, but in the example it is set to 29. This confuses users.

### :new: What is the new behavior (if this is a feature change)?

Corrected the documentation and the example. The documentation now mentions the user should use a "compileSDK" of 28 or higher and in the example code the value is set to 28.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Only documentation

### :memo: Links to relevant issues/docs

- Fixes #19 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop