### PR TITLE
kCLAuthorizationStatusAuthorizedWhenInUse was returning PermissionStatusDenied

### DIFF
--- a/packages/location_permissions/ios/Classes/LocationPermissionsPlugin.m
+++ b/packages/location_permissions/ios/Classes/LocationPermissionsPlugin.m
@@ -192,8 +192,8 @@
         case kCLAuthorizationStatusRestricted:
           return PermissionStatusRestricted;
         case kCLAuthorizationStatusDenied:
-        case kCLAuthorizationStatusAuthorizedWhenInUse:
           return PermissionStatusDenied;
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
         case kCLAuthorizationStatusAuthorizedAlways:
           return PermissionStatusGranted;
       }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

### :arrow_heading_down: What is the current behavior?
kCLAuthorizationStatusAuthorizedWhenInUse was returning PermissionStatusDenied

### :new: What is the new behavior (if this is a feature change)?
kCLAuthorizationStatusAuthorizedWhenInUse is now returning PermissionStatusGranted

### :boom: Does this PR introduce a breaking change?
No

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop