### PR TITLE
Synchonized gradle version with Flutter stable

### DIFF
--- a/packages/location_permissions/android/build.gradle
+++ b/packages/location_permissions/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 
@@ -35,5 +35,5 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.core:core:1.1.0'
 }

--- a/packages/location_permissions/example/android/app/build.gradle
+++ b/packages/location_permissions/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.baseflow.location_permissions_example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/location_permissions/example/android/build.gradle
+++ b/packages/location_permissions/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 

--- a/packages/location_permissions/example/android/gradle.properties
+++ b/packages/location_permissions/example/android/gradle.properties
@@ -1,1 +1,4 @@
+android.enableJetifier=true
+android.useAndroidX=true
+android.enableR8=true
 org.gradle.jvmargs=-Xmx1536M

--- a/packages/location_permissions/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/location_permissions/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Currently the used versions of the Grable Plugin and Gradle Wrapper are out of sync with the stable version of Flutter.

### :new: What is the new behavior (if this is a feature change)?

Bring the Gradle plugin and Gradle wrapper versions in sync with Flutter stable (1.12.13+hotfix.5).

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Compile and run the example project

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-plugins/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
