### PR TITLE
Fixes dropped parameter on requestPermission

### DIFF
--- a/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
+++ b/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
@@ -80,10 +80,9 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
   
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({
-    SERVICE_STATUS_DISABLED,
-    SERVICE_STATUS_ENABLED,
-    SERVICE_STATUS_NOT_APPLICABLE,
-    SERVICE_STATUS_UNKNOWN,
+    PERMISSION_LEVEL_AUTO,
+    PERMISSION_LEVEL_WHEN_IN_USE,
+    PERMISSION_LEVEL_ALWAYS,
   })
   private @interface PermissionLevel {}
 

--- a/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
+++ b/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
@@ -249,7 +249,7 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
       return;
     }
 
-    @PermissionStatus final int permissionStatus = checkPermissionStatus(activity);
+    @PermissionStatus final int permissionStatus = checkPermissionStatus(activity, permissionLevel);
     if (permissionStatus != PERMISSION_STATUS_GRANTED) {
       final List<String> names = getNamesForLevel(activity, permissionLevel);
 

--- a/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
+++ b/packages/location_permissions/android/src/main/java/com/baseflow/location_permissions/LocationPermissionsPlugin.java
@@ -251,7 +251,7 @@ public class LocationPermissionsPlugin implements MethodCallHandler, StreamHandl
 
     @PermissionStatus final int permissionStatus = checkPermissionStatus(activity);
     if (permissionStatus != PERMISSION_STATUS_GRANTED) {
-      final List<String> = getNamesForLevel(activity, permissionLevel);
+      final List<String> names = getNamesForLevel(activity, permissionLevel);
 
       ActivityCompat.requestPermissions(
           activity, names.toArray(new String[0]), PERMISSION_CODE);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The last version is ignoring the "permission level" parameter on Android

### :new: What is the new behavior (if this is a feature change)?
The library will respect the parameter (as on iOS)

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Change the parameter to "whileInUse", call requestPermission and it will anyway do automatic detection based on manifest.

### :memo: Links to relevant issues/docs
I think its related to
https://github.com/Baseflow/flutter-permission-plugins/issues/41

### :thinking: Checklist before submitting

- [ * ] All projects build
- [ * ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-permission-handlers/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ * ] Rebased onto current develop