### PR TITLE
conver serviceStatus of single stream to multi stream

### DIFF
--- a/packages/location_permissions/lib/src/location_permissions.dart
+++ b/packages/location_permissions/lib/src/location_permissions.dart
@@ -98,7 +98,8 @@ class LocationPermissions {
     assert(Platform.isAndroid,
         'Listening to service state changes is only supported on Android.');
 
-    return _eventChannel!.receiveBroadcastStream().map((dynamic status) =>
-        status ? ServiceStatus.enabled : ServiceStatus.disabled);
+    return _eventChannel!.receiveBroadcastStream().asBroadcastStream().map(
+        (dynamic status) =>
+            status ? ServiceStatus.enabled : ServiceStatus.disabled);
   }
 }


### PR DESCRIPTION
Hi, I'm new contributing.
I ran into a problem when I was listening to the status of the gps "serviceStatus" in multiple pages of my app, so I decided to make the "serviceStatus" be able to broadcast to multiple listeners

I consider that it is a minor change, it should not affect the operation of "serviceStatus"